### PR TITLE
Filter By Boundary new FilterByAreaMessage explanatory text

### DIFF
--- a/scss/components/_filter-by-boundary.scss
+++ b/scss/components/_filter-by-boundary.scss
@@ -22,3 +22,11 @@
     font-size: 11px;
   }
 }
+
+.filter-by-boundary-message {
+  font-size: 1.2rem;
+  font-weight: 500;
+
+  margin-bottom: $margin-10;
+  margin-left: $margin-10;
+}

--- a/src/components/OptionsFilters/FilterByAreaMessage.js
+++ b/src/components/OptionsFilters/FilterByAreaMessage.js
@@ -1,0 +1,35 @@
+import React, { Component, PropTypes } from 'react';
+
+class FilterByAreaMessage extends Component {
+  render() {
+    const { geo } = this.props;
+
+    // the stock message... or maybe not
+    let message = 'Choose a boundary type, then click an area on the map to filter crashes within that area.';
+    switch (geo) {
+      case 'custom':
+        message = 'Draw a custom area on the map.';
+        break;
+      case 'intersection':
+        message = 'The 500 most dangerous intersections over last 2 years. Zoom in to see 90-foot radius for each.';
+        break;
+      default:
+        break;
+    }
+
+    return (
+      <p className="filter-by-boundary-message">
+        {message}
+      </p>
+    );
+  }
+}
+
+FilterByAreaMessage.defaultProps = {
+};
+
+FilterByAreaMessage.propTypes = {
+  geo: PropTypes.string.isRequired,
+};
+
+export default FilterByAreaMessage;

--- a/src/components/OptionsFilters/index.js
+++ b/src/components/OptionsFilters/index.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 
 import OptionsContainer from './OptionsContainer';
 import FilterByArea from '../../containers/FilterByAreaConnected';
+import FilterByAreaMessage from '../../containers/FilterByAreaMessageConnected';
 import FilterByType from '../../containers/FilterByTypeConnected';
 import FilterByDate from '../../containers/FilterByDateConnected';
 import DownloadData from './DownloadData';
@@ -10,7 +11,7 @@ import FooterOptions from './FooterOptions';
 
 class OptionsFilters extends Component {
   render() {
-    const { height, maxDate, openModal } = this.props;
+    const { height, maxDate, openModal, geo } = this.props;
 
     return (
       <div className="ui right app-options-filters">
@@ -26,6 +27,7 @@ class OptionsFilters extends Component {
           </OptionsContainer>
           <hr />
           <OptionsContainer title={'Filter by Boundary'}>
+            <FilterByAreaMessage geo={geo} />
             <FilterByArea />
           </OptionsContainer>
           <hr />
@@ -57,13 +59,15 @@ class OptionsFilters extends Component {
 
 OptionsFilters.defaultProps = {
   maxDate: '',
-  height: 120
+  height: 120,
+  geo: '',
 };
 
 OptionsFilters.propTypes = {
   maxDate: PropTypes.string,
   openModal: PropTypes.func.isRequired,
-  height: PropTypes.number
+  height: PropTypes.number,
+  geo: PropTypes.string.isRequired,
 };
 
 export default OptionsFilters;

--- a/src/components/OptionsFilters/index.js
+++ b/src/components/OptionsFilters/index.js
@@ -11,7 +11,7 @@ import FooterOptions from './FooterOptions';
 
 class OptionsFilters extends Component {
   render() {
-    const { height, maxDate, openModal, geo } = this.props;
+    const { height, maxDate, openModal } = this.props;
 
     return (
       <div className="ui right app-options-filters">
@@ -27,7 +27,7 @@ class OptionsFilters extends Component {
           </OptionsContainer>
           <hr />
           <OptionsContainer title={'Filter by Boundary'}>
-            <FilterByAreaMessage geo={geo} />
+            <FilterByAreaMessage />
             <FilterByArea />
           </OptionsContainer>
           <hr />
@@ -60,14 +60,12 @@ class OptionsFilters extends Component {
 OptionsFilters.defaultProps = {
   maxDate: '',
   height: 120,
-  geo: '',
 };
 
 OptionsFilters.propTypes = {
   maxDate: PropTypes.string,
   openModal: PropTypes.func.isRequired,
   height: PropTypes.number,
-  geo: PropTypes.string.isRequired,
 };
 
 export default OptionsFilters;

--- a/src/containers/FilterByAreaMessageConnected.js
+++ b/src/containers/FilterByAreaMessageConnected.js
@@ -1,0 +1,9 @@
+import { connect } from 'react-redux';
+import FilterByArea from '../components/OptionsFilters/FilterByAreaMessage';
+
+const mapStateToProps = ({ filterArea: { geo } }) => ({
+  geo,
+});
+
+export default connect(mapStateToProps, {
+})(FilterByArea);


### PR DESCRIPTION
This addresses the request in #82 to add some explanation of the types of areas, in the Filter By Boundary section. This was particularly for Custom (people didn't know to start clicking the map to draw) and Intersections (people didn't know to zoom in and look for blue circles).
