### PR TITLE
Crash Mapper issue 97 - Map and Chart cross-links

### DIFF
--- a/src/components/LeafletMap/index.js
+++ b/src/components/LeafletMap/index.js
@@ -60,6 +60,9 @@ class LeafletMap extends Component {
     // if loading both/neither, that's already handled by standard props updates
     if (geo && geo !== 'citywide' && !identifier) {
       this.props.fetchGeoPolygons(geo);
+    } else if (geo && identifier) {
+      const sql = configureMapSQL(this.props);
+      this.fitMapBounds(sql);
     }
   }
 

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -55,7 +55,8 @@ export const makeDefaultState = () => {
     return geos[0];
   };
 
-  // parse query params
+  // parse query params, with compatibility hack issue 97 to accept Chart View identifier
+  // which is really the full string name with a borough prefix
   Object.keys(q).forEach((key) => {
     const decoded = decodeURIComponent(q[key]);
     if (isJsonString(decoded)) {
@@ -64,6 +65,17 @@ export const makeDefaultState = () => {
       p[key] = decoded;
     }
   });
+  if (p.identifier) {
+    if (p.identifier.indexOf(',') !== -1) {
+      p.identifier = p.identifier.split(',')[1];
+    }
+    p.identifier = p.identifier.trim();
+
+    const identifierEndsInNumber = p.identifier.match(/(\d+)$/);
+    if (identifierEndsInNumber) {
+      p.identifier = parseInt(identifierEndsInNumber[1], 10);
+    }
+  }
 
   return {
     filterDate: {

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -65,7 +65,7 @@ export const makeDefaultState = () => {
       p[key] = decoded;
     }
   });
-  if (p.identifier) {
+  if (p.identifier && typeof p.identifier === 'string') {
     if (p.identifier.indexOf(',') !== -1) {
       p.identifier = p.identifier.split(',')[1];
     }
@@ -73,7 +73,7 @@ export const makeDefaultState = () => {
 
     const identifierEndsInNumber = p.identifier.match(/(\d+)$/);
     if (identifierEndsInNumber) {
-      p.identifier = parseInt(identifierEndsInNumber[1], 10);
+      p.identifier = identifierEndsInNumber[1];
     }
   }
 


### PR DESCRIPTION
https://github.com/GreenInfo-Network/nyc-crash-mapper/issues/97

The chart app and map app have totally different ideas of identifying polygonal areas: `identifier` for the Map (the unique name/ID, e.g. *23*) and `primary` for the Chart (a unique but verbose string e.g. *Bronx, NYPD Precinct 123*) As a result, the Map links from Chart and the 3 Chart links from Map don't work as expected: they load the expected area type, but not the specific area and its data.

This PR will fix this, so the cross-links work properly.
* Coming from any chart to the Map, the data are filtered to the area and the map zooms to the area.
* Coming from the Map to any of the chart links, the area will be selected and data displayed.
